### PR TITLE
Add Binder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2017, Gilles Louppe
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# tutorials-iml2017
+# IML Tutorials 2017
 
-Tutorials given by Gilles Louppe, as part of the IML Machine Learning Workshop, March 20-22 2017, CERN. https://indico.cern.ch/event/595059/other-view?view=standard
+Tutorials given by [Gilles Louppe](https://glouppe.github.io/), as part of the [IML Machine Learning Workshop](https://indico.cern.ch/event/595059/timetable/?view=standard), March 20-22 2017, CERN.
 
-Requirements: a Python distribution with the Scikit-Learn. 
+**Requirements:** a Python distribution with the [Scikit-Learn](http://scikit-learn.org/stable/).
 
 1. Jump to https://www.continuum.io/downloads and download the installer.
 2. `bash Anaconda3-4.3.1-Linux-x86_64.sh` (or whatever installer you picked)
@@ -12,5 +12,7 @@ You are ready to go!
 
 ---
 
-- Nbviewer: https://nbviewer.jupyter.org/github/glouppe/tutorials-iml2017/tree/master/
-- Contact: <a href="https://twitter.com/glouppe">@glouppe</a> | BSD 3-clause license
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/glouppe/tutorials-iml2017/master)
+[![nbviewer](https://img.shields.io/badge/view%20on-nbviewer-brightgreen.svg)](https://nbviewer.jupyter.org/github/glouppe/tutorials-iml2017/tree/master/)
+- Contact: <a href="https://twitter.com/glouppe">@glouppe</a>
+- [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+matplotlib
+numpy
+pandas
+scipy
+sklearn


### PR DESCRIPTION
@glouppe This PR will "Binderize" the repo making the tutorials runnable inside a web browser. As this tutorial is linked off of the [HEP ML Resources listing repo](https://github.com/iml-wg/HEP-ML-Resources#tutorials) it would be nice to make this tutorial as easy to get up an running as possible.

The `requirements.txt` is slightly more extensible than needed (as pandas and scipy are not needed to run the tutorial as is) but the extra dependencies are small enough and very useful and so added should the user want to explore the ecosystem more in the Binder.

The "launch Binder" badge in the README is correct for the original repo. The only thing that needs to be done after the PR is accepted is to build the image:
- visit https://mybinder.org/
- paste "https://github.com/glouppe/tutorials-iml2017" into the "GitHub repo or URL" text box
- click "launch"

Once the build has completed the repo will be Binderized and ready.

This PR can be squashed and merged --- I don't think there is any real reason to show all the commits, but I'll leave that up to the owner. :)